### PR TITLE
[ci] Fix validation of kiwi repositories

### DIFF
--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -13,7 +13,6 @@ class Kiwi::Repository < ApplicationRecord
   belongs_to :image
 
   #### Callbacks macros: before_save, after_save, etc.
-  before_update :not_outdated
 
   #### Scopes (first the default_scope macro if is used)
 
@@ -27,6 +26,7 @@ class Kiwi::Repository < ApplicationRecord
   validates :repo_type, inclusion: { in: %w(apt-deb rpm-dir rpm-md yast2) }
   validates :replaceable, inclusion: { in: [true, false] }
   validates :imageinclude, :prefer_license, inclusion: { in: [true, false] }, allow_nil: true
+  validate :not_outdated, on: :update
 
   #### Class methods using self. (public and then private)
 
@@ -76,7 +76,7 @@ class Kiwi::Repository < ApplicationRecord
   private
 
   def not_outdated
-    !image.package.kiwi_image_outdated?
+    errors.add(:base, 'Image configuration has changed') if image.package.kiwi_image_outdated?
   end
 end
 

--- a/src/api/app/models/kiwi/repository.rb
+++ b/src/api/app/models/kiwi/repository.rb
@@ -23,7 +23,7 @@ class Kiwi::Repository < ApplicationRecord
   validates :order, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   # TODO: repo_type value depends on packagemanager element
   # https://doc.opensuse.org/projects/kiwi/doc/#sec.description.repository
-  validates :repo_type, inclusion: { in: %w(apt-deb rpm-dir rpm-md yast2) }
+  validates :repo_type, inclusion: { in: %w[apt-deb rpm-dir rpm-md yast2] }
   validates :replaceable, inclusion: { in: [true, false] }
   validates :imageinclude, :prefer_license, inclusion: { in: [true, false] }, allow_nil: true
   validate :not_outdated, on: :update

--- a/src/api/spec/models/kiwi/repository_spec.rb
+++ b/src/api/spec/models/kiwi/repository_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Kiwi::Repository, type: :model do
       allow_any_instance_of(Package).to receive(:kiwi_image_outdated?) { true }
     end
 
-    it { expect{ kiwi_repository.update_attributes!(priority: 3) }.to raise_error(ActiveRecord::RecordNotSaved, 'Failed to save the record') }
+    it { expect{ kiwi_repository.update_attributes!(priority: 3) }.to raise_error(
+      ActiveRecord::RecordInvalid, 'Validation failed: Image configuration has changed') }
   end
 
   describe '.to_xml' do


### PR DESCRIPTION
When the image configuration an kiwi repository belongs to has
changed, the record shouldn't be saved. The test for this was failing
because we were using a before callback to ensure that.

Using a validation instead fixes this and seems to be the right way
given that appears to be a validation.

Another sollution would be to use the before_validation callback. But
this seems to be mainly meant preperational operations.

  http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html#module-ActiveRecord::Callbacks-label-before_validation-2A+returning+statements