### PR TITLE
Use workflow conf. file from the base branch for GitHub

### DIFF
--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -23,7 +23,7 @@ module Workflows
       case @scm_payload[:scm]
       when 'github'
         client = Octokit::Client.new(access_token: @token.scm_token, api_endpoint: @scm_payload[:api_endpoint])
-        client.content("#{@scm_payload[:target_repository_full_name]}", path: '/.obs/workflows.yml')[:download_url]
+        client.content("#{@scm_payload[:target_repository_full_name]}", path: '/.obs/workflows.yml', ref: @scm_payload[:target_branch])[:download_url]
       when 'gitlab'
         "#{@scm_payload[:api_endpoint]}/#{@scm_payload[:path_with_namespace]}/-/raw/#{@scm_payload[:target_branch]}/.obs/workflows.yml"
       end


### PR DESCRIPTION
Until this change, we always use the workflow configuration file from
the default branch of a repository.

Add a missing "ref" attribute to the Octokit call, with the branch that
must be used, to be able to retrieve the correct workflow configuration
file.